### PR TITLE
Add alternative command if error encountered

### DIFF
--- a/remote-access/ssh/passwordless.md
+++ b/remote-access/ssh/passwordless.md
@@ -60,8 +60,13 @@ To copy your public key to your Raspberry Pi, use the following command to appen
 cat ~/.ssh/id_rsa.pub | ssh <USERNAME>@<IP-ADDRESS> 'cat >> .ssh/authorized_keys'
 ```
 
-Note that this time you will have to authenticate with your password.
+You will have to authenticate with your password.
 
+Note. When you run the above command you may see an error along the lines of: `.ssh/authorized_keys: No such file or directory`
+This is because in some cases the hidden directory `.ssh` or the file called `authorized_keys` may not already exist.  If this happens try the following:
+```
+cat ~/.ssh/id_rsa.pub | ssh <USERNAME>@<IP-ADDRESS> 'mkdir .ssh/ && cat >> .ssh/authorized_keys'
+```
 Now try `ssh <USER>@<IP-ADDRESS>` and you should connect without a password prompt.
 
 If this did not work, delete your keys with `rm ~/.ssh/id*` and follow the instructions again.


### PR DESCRIPTION
This change provides an alternative command to use if the user encounters an error because  .ssh directory or authorized_keys file is missing.
This change should fix Issue 285 that I raised.
Tests undertaken: To test this I renamed my remote .ssh folder and ran the command suggested. I had to enter my password again.  I was then able to log in again remotely without supplying the password.
